### PR TITLE
Avoid sharing state across end-to-end test executions

### DIFF
--- a/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
+++ b/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
@@ -35,7 +35,7 @@ final class EssentialFeedAPIEndToEndTests: XCTestCase {
     
     private func getFeedResult(file: StaticString = #filePath, line: UInt = #line) -> LoadFeedResult? {
         let testServerURL = URL(string: "https://essentialdeveloper.com/feed-case-study/test-api/feed")!
-        let client = URLSessionHTTPClient()
+        let client = URLSessionHTTPClient(session: URLSession(configuration: .ephemeral))
         let loader = RemoteFeedLoader(url: testServerURL, client: client)
         trackMemoryLeak(client, file: file, line: line)
         trackMemoryLeak(loader, file: file, line: line)


### PR DESCRIPTION
Use ephemeral URL session configuration to avoid sharing state across test executions (in-disk cache artifacts).