### PR TITLE
Internal memory management and further refactorings for the Cache Feed Use Case

### DIFF
--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		6A702B7E298C1F92004F3C06 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6ADA40B82979A05800E87609 /* EssentialFeed.framework */; };
 		6A702B84298C2A6B004F3C06 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A702B72298BC4AE004F3C06 /* XCTestCase+MemoryLeakTracking.swift */; };
 		6A7DFC392994CB7200768BA7 /* CacheFeedUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7DFC382994CB7200768BA7 /* CacheFeedUseCaseTests.swift */; };
+		6A7DFC3C29979E7C00768BA7 /* LocalFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7DFC3B29979E7C00768BA7 /* LocalFeedLoader.swift */; };
 		6A80096A297FE3F90096BFF3 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A800969297FE3F90096BFF3 /* LoadFeedFromRemoteUseCaseTests.swift */; };
 		6A80096D29812E920096BFF3 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A80096C29812E910096BFF3 /* RemoteFeedLoader.swift */; };
 		6AA00F53298508AC001F8CB0 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA00F52298508AC001F8CB0 /* HTTPClient.swift */; };
@@ -49,6 +50,7 @@
 		6A702B7A298C1F92004F3C06 /* EssentialFeedAPIEndToEndTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedAPIEndToEndTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A702B7C298C1F92004F3C06 /* EssentialFeedAPIEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialFeedAPIEndToEndTests.swift; sourceTree = "<group>"; };
 		6A7DFC382994CB7200768BA7 /* CacheFeedUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFeedUseCaseTests.swift; sourceTree = "<group>"; };
+		6A7DFC3B29979E7C00768BA7 /* LocalFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedLoader.swift; sourceTree = "<group>"; };
 		6A800969297FE3F90096BFF3 /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
 		6A80096C29812E910096BFF3 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
 		6AA00F52298508AC001F8CB0 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
@@ -112,6 +114,14 @@
 			path = "Feed Cache";
 			sourceTree = "<group>";
 		};
+		6A7DFC3A29979E6400768BA7 /* Feed Cache */ = {
+			isa = PBXGroup;
+			children = (
+				6A7DFC3B29979E7C00768BA7 /* LocalFeedLoader.swift */,
+			);
+			path = "Feed Cache";
+			sourceTree = "<group>";
+		};
 		6A80096B29812E670096BFF3 /* Feed API */ = {
 			isa = PBXGroup;
 			children = (
@@ -157,6 +167,7 @@
 			children = (
 				6ADA40BB2979A05800E87609 /* EssentialFeed.h */,
 				6ADA40BC2979A05800E87609 /* EssentialFeed.docc */,
+				6A7DFC3A29979E6400768BA7 /* Feed Cache */,
 				6ADA40D72979A57500E87609 /* Feed Feature */,
 				6A80096B29812E670096BFF3 /* Feed API */,
 			);
@@ -336,6 +347,7 @@
 				6ADA40D52979A41200E87609 /* FeedLoader.swift in Sources */,
 				6AA00F552985090D001F8CB0 /* FeedItemsMapper.swift in Sources */,
 				6ADA40D32979A08900E87609 /* FeedItem.swift in Sources */,
+				6A7DFC3C29979E7C00768BA7 /* LocalFeedLoader.swift in Sources */,
 				6ADA40BD2979A05800E87609 /* EssentialFeed.docc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		6A702B84298C2A6B004F3C06 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A702B72298BC4AE004F3C06 /* XCTestCase+MemoryLeakTracking.swift */; };
 		6A7DFC392994CB7200768BA7 /* CacheFeedUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7DFC382994CB7200768BA7 /* CacheFeedUseCaseTests.swift */; };
 		6A7DFC3C29979E7C00768BA7 /* LocalFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7DFC3B29979E7C00768BA7 /* LocalFeedLoader.swift */; };
+		6A7DFC3E29979F3300768BA7 /* FeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7DFC3D29979F3300768BA7 /* FeedStore.swift */; };
 		6A80096A297FE3F90096BFF3 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A800969297FE3F90096BFF3 /* LoadFeedFromRemoteUseCaseTests.swift */; };
 		6A80096D29812E920096BFF3 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A80096C29812E910096BFF3 /* RemoteFeedLoader.swift */; };
 		6AA00F53298508AC001F8CB0 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA00F52298508AC001F8CB0 /* HTTPClient.swift */; };
@@ -51,6 +52,7 @@
 		6A702B7C298C1F92004F3C06 /* EssentialFeedAPIEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialFeedAPIEndToEndTests.swift; sourceTree = "<group>"; };
 		6A7DFC382994CB7200768BA7 /* CacheFeedUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFeedUseCaseTests.swift; sourceTree = "<group>"; };
 		6A7DFC3B29979E7C00768BA7 /* LocalFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedLoader.swift; sourceTree = "<group>"; };
+		6A7DFC3D29979F3300768BA7 /* FeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStore.swift; sourceTree = "<group>"; };
 		6A800969297FE3F90096BFF3 /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
 		6A80096C29812E910096BFF3 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
 		6AA00F52298508AC001F8CB0 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				6A7DFC3B29979E7C00768BA7 /* LocalFeedLoader.swift */,
+				6A7DFC3D29979F3300768BA7 /* FeedStore.swift */,
 			);
 			path = "Feed Cache";
 			sourceTree = "<group>";
@@ -341,6 +344,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A7DFC3E29979F3300768BA7 /* FeedStore.swift in Sources */,
 				6A702B75298BE29E004F3C06 /* URLSessionHTTPClient.swift in Sources */,
 				6A80096D29812E920096BFF3 /* RemoteFeedLoader.swift in Sources */,
 				6AA00F53298508AC001F8CB0 /* HTTPClient.swift in Sources */,

--- a/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/Feed Cache/FeedStore.swift
@@ -1,0 +1,16 @@
+//
+//  FeedStore.swift
+//  EssentialFeed
+//
+//  Created by Ibrokhim Movlonov on 11/02/23.
+//
+
+import Foundation
+
+public protocol FeedStore {
+    typealias DeletionCompletion = (Error?) -> Void
+    typealias InsertionCompletion = (Error?) -> Void
+    
+    func deleteCachedFeed(completion: @escaping DeletionCompletion)
+    func insert(_ items: [FeedItem], timestamp: Date, completion: @escaping InsertionCompletion)
+}

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -36,11 +36,3 @@ public final class LocalFeedLoader {
         }
     }
 }
-
-public protocol FeedStore {
-    typealias DeletionCompletion = (Error?) -> Void
-    typealias InsertionCompletion = (Error?) -> Void
-    
-    func deleteCachedFeed(completion: @escaping DeletionCompletion)
-    func insert(_ items: [FeedItem], timestamp: Date, completion: @escaping InsertionCompletion)
-}

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -11,12 +11,14 @@ public final class LocalFeedLoader {
     private let store: FeedStore
     private let currentDate: () -> Date
     
+    public typealias SaveResult = Error?
+    
     public init(store: FeedStore, currentDate: @escaping () -> Date) {
         self.store = store
         self.currentDate = currentDate
     }
     
-    public func save(_ items: [FeedItem], completion: @escaping (Error?) -> Void) {
+    public func save(_ items: [FeedItem], completion: @escaping (SaveResult) -> Void) {
         store.deleteCachedFeed { [weak self] error in
             guard let self = self else { return }
             
@@ -28,7 +30,7 @@ public final class LocalFeedLoader {
         }
     }
     
-    private func cache(_ items: [FeedItem], with completion: @escaping (Error?) -> Void) {
+    private func cache(_ items: [FeedItem], with completion: @escaping (SaveResult) -> Void) {
         store.insert(items, timestamp: self.currentDate()) { [weak self] error in
             guard self != nil else { return }
             

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -1,0 +1,46 @@
+//
+//  LocalFeedLoader.swift
+//  EssentialFeed
+//
+//  Created by Ibrokhim Movlonov on 11/02/23.
+//
+
+import Foundation
+
+public final class LocalFeedLoader {
+    private let store: FeedStore
+    private let currentDate: () -> Date
+    
+    public init(store: FeedStore, currentDate: @escaping () -> Date) {
+        self.store = store
+        self.currentDate = currentDate
+    }
+    
+    public func save(_ items: [FeedItem], completion: @escaping (Error?) -> Void) {
+        store.deleteCachedFeed { [weak self] error in
+            guard let self = self else { return }
+            
+            if let cacheDeletionError = error {
+                completion(cacheDeletionError)
+            } else {
+                self.cache(items, with: completion)
+            }
+        }
+    }
+    
+    private func cache(_ items: [FeedItem], with completion: @escaping (Error?) -> Void) {
+        store.insert(items, timestamp: self.currentDate()) { [weak self] error in
+            guard self != nil else { return }
+            
+            completion(error)
+        }
+    }
+}
+
+public protocol FeedStore {
+    typealias DeletionCompletion = (Error?) -> Void
+    typealias InsertionCompletion = (Error?) -> Void
+    
+    func deleteCachedFeed(completion: @escaping DeletionCompletion)
+    func insert(_ items: [FeedItem], timestamp: Date, completion: @escaping InsertionCompletion)
+}

--- a/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -15,7 +15,9 @@ class LocalFeedLoader {
     }
     
     func save(_ items: [FeedItem], completion: @escaping (Error?) -> Void) {
-        store.deleteCachedFeed { [unowned self] error in
+        store.deleteCachedFeed { [weak self] error in
+            guard let self = self else { return }
+            
             if error == nil {
                 self.store.insert(items, timestamp: self.currentDate(), completion: completion)
             } else {
@@ -98,6 +100,19 @@ final class CacheFeedUseCaseTests: XCTestCase {
             store.completeDeletionSuccessfully()
             store.completeInsertionSuccessfully()
         }
+    }
+    
+    func test_save_doesNotDeliverDeletionErrorAfterSUTInstanceHasBeenDeallocated() {
+        let store = FeedStoreSpy()
+        var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
+        
+        var receivedResults = [Error?]()
+        sut?.save([uniqueItem()]) { receivedResults.append($0) }
+        
+        sut = nil
+        store.completeDeletion(with: anyNSError())
+        
+        XCTAssertTrue(receivedResults.isEmpty)
     }
     
     // MARK: - Helpers

--- a/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -5,44 +5,6 @@
 import XCTest
 import EssentialFeed
 
-class LocalFeedLoader {
-    private let store: FeedStore
-    private let currentDate: () -> Date
-    
-    init(store: FeedStore, currentDate: @escaping () -> Date) {
-        self.store = store
-        self.currentDate = currentDate
-    }
-    
-    func save(_ items: [FeedItem], completion: @escaping (Error?) -> Void) {
-        store.deleteCachedFeed { [weak self] error in
-            guard let self = self else { return }
-            
-            if let cacheDeletionError = error {
-                completion(cacheDeletionError)
-            } else {
-                self.cache(items, with: completion)
-            }
-        }
-    }
-    
-    private func cache(_ items: [FeedItem], with completion: @escaping (Error?) -> Void) {
-        store.insert(items, timestamp: self.currentDate()) { [weak self] error in
-            guard self != nil else { return }
-            
-            completion(error)
-        }
-    }
-}
-
-protocol FeedStore {
-    typealias DeletionCompletion = (Error?) -> Void
-    typealias InsertionCompletion = (Error?) -> Void
-    
-    func deleteCachedFeed(completion: @escaping DeletionCompletion)
-    func insert(_ items: [FeedItem], timestamp: Date, completion: @escaping InsertionCompletion)
-}
-
 final class CacheFeedUseCaseTests: XCTestCase {
     
     func test_init_doesNotMessageStoreUponCreation() {

--- a/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -18,13 +18,13 @@ class LocalFeedLoader {
         store.deleteCachedFeed { [weak self] error in
             guard let self = self else { return }
             
-            if error == nil {
+            if let cacheDeletionError = error {
+                completion(cacheDeletionError)
+            } else {
                 self.store.insert(items, timestamp: self.currentDate()) { [weak self] error in
                     guard self != nil else { return }
                     completion(error)
                 }
-            } else {
-                completion(error)
             }
         }
     }

--- a/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -19,7 +19,10 @@ class LocalFeedLoader {
             guard let self = self else { return }
             
             if error == nil {
-                self.store.insert(items, timestamp: self.currentDate(), completion: completion)
+                self.store.insert(items, timestamp: self.currentDate()) { [weak self] error in
+                    guard self != nil else { return }
+                    completion(error)
+                }
             } else {
                 completion(error)
             }
@@ -111,6 +114,20 @@ final class CacheFeedUseCaseTests: XCTestCase {
         
         sut = nil
         store.completeDeletion(with: anyNSError())
+        
+        XCTAssertTrue(receivedResults.isEmpty)
+    }
+    
+    func test_save_doesNotDeliverInsertionErrorAfterSUTInstanceHasBeenDeallocated() {
+        let store = FeedStoreSpy()
+        var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
+        
+        var receivedResults = [Error?]()
+        sut?.save([uniqueItem()]) { receivedResults.append($0) }
+        
+        store.completeDeletionSuccessfully()
+        sut = nil
+        store.completeInsertion(with: anyNSError())
         
         XCTAssertTrue(receivedResults.isEmpty)
     }

--- a/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -21,11 +21,16 @@ class LocalFeedLoader {
             if let cacheDeletionError = error {
                 completion(cacheDeletionError)
             } else {
-                self.store.insert(items, timestamp: self.currentDate()) { [weak self] error in
-                    guard self != nil else { return }
-                    completion(error)
-                }
+                self.cache(items, with: completion)
             }
+        }
+    }
+    
+    private func cache(_ items: [FeedItem], with completion: @escaping (Error?) -> Void) {
+        store.insert(items, timestamp: self.currentDate()) { [weak self] error in
+            guard self != nil else { return }
+            
+            completion(error)
         }
     }
 }

--- a/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -76,7 +76,7 @@ final class CacheFeedUseCaseTests: XCTestCase {
         let store = FeedStoreSpy()
         var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
         
-        var receivedResults = [Error?]()
+        var receivedResults = [LocalFeedLoader.SaveResult]()
         sut?.save([uniqueItem()]) { receivedResults.append($0) }
         
         sut = nil
@@ -89,7 +89,7 @@ final class CacheFeedUseCaseTests: XCTestCase {
         let store = FeedStoreSpy()
         var sut: LocalFeedLoader? = LocalFeedLoader(store: store, currentDate: Date.init)
         
-        var receivedResults = [Error?]()
+        var receivedResults = [LocalFeedLoader.SaveResult]()
         sut?.save([uniqueItem()]) { receivedResults.append($0) }
         
         store.completeDeletionSuccessfully()


### PR DESCRIPTION
- Check expected behavior after deallocation
- Proper memory-management of captured references within deeply nested closures
- Move types to production